### PR TITLE
feat: implement share settings and replay onboarding

### DIFF
--- a/airmeishi/Models/BusinessCard.swift
+++ b/airmeishi/Models/BusinessCard.swift
@@ -83,6 +83,20 @@ struct BusinessCard: Codable, Identifiable, Equatable, Hashable {
 
     return filtered
   }
+
+  /// Get filtered business card based on explicit field set
+  func filteredCard(for fields: Set<BusinessCardField>) -> BusinessCard {
+    var filtered = self
+    if !fields.contains(.name) { filtered.name = "" }
+    if !fields.contains(.title) { filtered.title = nil }
+    if !fields.contains(.company) { filtered.company = nil }
+    if !fields.contains(.email) { filtered.email = nil }
+    if !fields.contains(.phone) { filtered.phone = nil }
+    if !fields.contains(.profileImage) { filtered.profileImage = nil }
+    if !fields.contains(.socialNetworks) { filtered.socialNetworks = [] }
+    if !fields.contains(.skills) { filtered.skills = [] }
+    return filtered
+  }
 }
 
 /// Social network information

--- a/airmeishi/Services/Card/QRCodeGenerationService.swift
+++ b/airmeishi/Services/Card/QRCodeGenerationService.swift
@@ -14,6 +14,33 @@ final class QRCodeGenerationService {
 
   func generateImage(
     for card: BusinessCard,
+    fields: Set<BusinessCardField>,
+    expirationDate: Date? = nil
+  ) -> CardResult<UIImage> {
+    let filteredCard = card.filteredCard(for: fields)
+    let mySealedRoute = SecureKeyManager.shared.mySealedRoute
+    let snapshot = BusinessCardSnapshot(card: filteredCard, sealedRoute: mySealedRoute)
+    let shareId = UUID()
+    let payload = QRPlaintextPayload(snapshot: snapshot, shareId: shareId, expirationDate: expirationDate)
+    let envelope = QRCodeEnvelope(
+      format: .plaintext,
+      sharingLevel: .public,
+      shareId: shareId,
+      plaintext: payload
+    )
+    do {
+      let data = try JSONEncoder.qrEncoder.encode(envelope)
+      guard let json = String(data: data, encoding: .utf8) else {
+        return .failure(.sharingError("Failed to encode QR envelope"))
+      }
+      return generateImage(from: json)
+    } catch {
+      return .failure(.sharingError("Failed to encode QR envelope: \(error.localizedDescription)"))
+    }
+  }
+
+  func generateImage(
+    for card: BusinessCard,
     sharingLevel: SharingLevel,
     expirationDate: Date? = nil
   ) -> CardResult<UIImage> {

--- a/airmeishi/Services/Card/QRCodeManager.swift
+++ b/airmeishi/Services/Card/QRCodeManager.swift
@@ -36,6 +36,21 @@ final class QRCodeManager: ObservableObject {
 
   func generateQRCode(
     for businessCard: BusinessCard,
+    fields: Set<BusinessCardField>,
+    expirationDate: Date? = nil
+  ) -> CardResult<UIImage> {
+    isGenerating = true
+    let result = generationService.generateImage(
+      for: businessCard,
+      fields: fields,
+      expirationDate: expirationDate
+    )
+    isGenerating = false
+    return result
+  }
+
+  func generateQRCode(
+    for businessCard: BusinessCard,
     sharingLevel: SharingLevel,
     expirationDate: Date? = nil
   ) -> CardResult<UIImage> {

--- a/airmeishi/Views/Common/MainTabView.swift
+++ b/airmeishi/Views/Common/MainTabView.swift
@@ -114,6 +114,9 @@ struct MainTabView: View {
     } else {
       GeometryReader { geometry in
         ZStack(alignment: .bottom) {
+          Color.Theme.pageBg
+            .ignoresSafeArea()
+
           TabView(selection: $selectedTab) {
             PeopleListView()
               .tag(MainAppTab.people.rawValue)
@@ -132,7 +135,6 @@ struct MainTabView: View {
           CustomFloatingTabBar(selectedTab: $selectedTab)
             .padding(.bottom, max(geometry.safeAreaInsets.bottom, 16))
         }
-        .background(Color.Theme.pageBg)
         .ignoresSafeArea(edges: .bottom)
       }
     }

--- a/airmeishi/Views/Common/MainTabView.swift
+++ b/airmeishi/Views/Common/MainTabView.swift
@@ -102,8 +102,8 @@ struct MainTabView: View {
         Tab(MainAppTab.people.title, systemImage: MainAppTab.people.systemImage, value: MainAppTab.people.rawValue) {
           PeopleListView()
         }
-        Tab(MainAppTab.scan.title, systemImage: MainAppTab.scan.systemImage, value: MainAppTab.scan.rawValue) {
-          ScanTabView()
+        Tab(MainAppTab.share.title, systemImage: MainAppTab.share.systemImage, value: MainAppTab.share.rawValue) {
+          SharingTabView()
         }
         Tab(MainAppTab.me.title, systemImage: MainAppTab.me.systemImage, value: MainAppTab.me.rawValue) {
           MeTabView()
@@ -112,30 +112,29 @@ struct MainTabView: View {
       .tint(Color.Theme.primaryBlue)
       .toolbarColorScheme(.dark, for: .tabBar)
     } else {
-      ZStack(alignment: .bottom) {
-        TabView(selection: $selectedTab) {
-          PeopleListView()
-            .tag(MainAppTab.people.rawValue)
+      GeometryReader { geometry in
+        ZStack(alignment: .bottom) {
+          TabView(selection: $selectedTab) {
+            PeopleListView()
+              .tag(MainAppTab.people.rawValue)
 
-          ScanTabView()
-            .tag(MainAppTab.scan.rawValue)
+            SharingTabView()
+              .tag(MainAppTab.share.rawValue)
 
-          MeTabView()
-            .tag(MainAppTab.me.rawValue)
-        }
-        .tabViewStyle(DefaultTabViewStyle())
-        .toolbarBackground(.hidden, for: .tabBar)
-        .toolbar(.hidden, for: .tabBar)
-        .padding(.bottom, 80)
-
-        VStack(spacing: 0) {
-          Spacer()
+            MeTabView()
+              .tag(MainAppTab.me.rawValue)
+          }
+          .tabViewStyle(DefaultTabViewStyle())
+          .toolbarBackground(.hidden, for: .tabBar)
+          .toolbar(.hidden, for: .tabBar)
+          .padding(.bottom, 80)
 
           CustomFloatingTabBar(selectedTab: $selectedTab)
-            .padding(.bottom, 24)
+            .padding(.bottom, max(geometry.safeAreaInsets.bottom, 16))
         }
+        .background(Color.Theme.pageBg)
+        .ignoresSafeArea(edges: .bottom)
       }
-      .ignoresSafeArea(edges: .bottom)
     }
   }
 
@@ -160,7 +159,7 @@ struct MainTabView: View {
       )
 
     case .navigateToSharing:
-      selectedTab = MainAppTab.scan.rawValue
+      selectedTab = MainAppTab.share.rawValue
 
     case .navigateToContacts:
       selectedTab = MainAppTab.people.rawValue

--- a/airmeishi/Views/Common/TabBarComponents.swift
+++ b/airmeishi/Views/Common/TabBarComponents.swift
@@ -4,13 +4,13 @@ import SwiftUI
 
 enum MainAppTab: Int, CaseIterable {
   case people = 0
-  case scan = 1
+  case share = 1
   case me = 2
 
   var title: String {
     switch self {
     case .people: "People"
-    case .scan: "Scan"
+    case .share: "Share"
     case .me: "Me"
     }
   }
@@ -18,7 +18,7 @@ enum MainAppTab: Int, CaseIterable {
   var systemImage: String {
     switch self {
     case .people: "person.2.fill"
-    case .scan: "qrcode.viewfinder"
+    case .share: "dot.radiowaves.up.forward"
     case .me: "person.text.rectangle"
     }
   }

--- a/airmeishi/Views/Onboarding/DarkProfileSetupForm.swift
+++ b/airmeishi/Views/Onboarding/DarkProfileSetupForm.swift
@@ -9,91 +9,130 @@ struct DarkProfileSetupForm: View {
   @Binding var wallet: String
 
   @State private var hasAttemptedNext = false
+  @FocusState private var focusedField: Field?
+
+  private enum Field: Hashable {
+    case username, link, xTwitter, linkedIn, wallet
+  }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 24) {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 24) {
 
-      VStack(alignment: .center, spacing: 8) {
-        Text("Hi,")
-          .font(.system(size: 28, weight: .bold))
-          .foregroundColor(.white)
-        Text("It's good to have you here <3\nLet's set up your profile")
-          .font(.system(size: 14))
-          .foregroundColor(Color.Theme.textSecondary)
-          .multilineTextAlignment(.center)
-      }
-      .frame(maxWidth: .infinity)
-      .padding(.bottom, 24)
-
-      // Username field
-      DarkInputField(
-        title: "Choose your username",
-        placeholder: "Enter your username",
-        text: $username,
-        isRequired: true,
-        errorMessage: (hasAttemptedNext && username.isEmpty) ? "Username is required" : nil
-      )
-
-      // Link field
-      DarkInputField(
-        title: "Link",
-        placeholder: "https://yoursite.com",
-        text: $link,
-        isRequired: false
-      )
-
-      // X field
-      DarkInputField(
-        title: "X(twitter)",
-        placeholder: "https://x.com/username",
-        text: $xTwitter,
-        isRequired: false
-      )
-
-      // LinkedIn field
-      DarkInputField(
-        title: "LinkedIn",
-        placeholder: "linkedin/links/here",
-        text: $linkedIn,
-        isRequired: false
-      )
-
-      VStack(alignment: .leading, spacing: 4) {
-        Text("Export")
-          .font(.system(size: 14, weight: .bold))
-          .foregroundColor(.white)
-        Text("You can do this later or whenever you're ready to export your data.")
-          .font(.system(size: 12))
-          .foregroundColor(Color.Theme.textTertiary)
-      }
-
-      // Wallet field
-      DarkInputField(
-        title: "Link to your ERC20 wallet (?)",
-        placeholder: "0x...",
-        text: $wallet,
-        isRequired: false
-      )
-
-      Spacer(minLength: 40)
-
-      Button(action: {
-        hasAttemptedNext = true
-        if !username.isEmpty {
-          HapticFeedbackManager.shared.heavyImpact()
-          onNext()
-        } else {
-          HapticFeedbackManager.shared.errorNotification()
+        VStack(alignment: .center, spacing: 8) {
+          Text("Hi,")
+            .font(.system(size: 28, weight: .bold))
+            .foregroundColor(.white)
+          Text("It's good to have you here <3\nLet's set up your profile")
+            .font(.system(size: 14))
+            .foregroundColor(Color.Theme.textSecondary)
+            .multilineTextAlignment(.center)
         }
-      }) {
-        Text("Next")
+        .frame(maxWidth: .infinity)
+        .padding(.bottom, 24)
+
+        // Username field
+        DarkInputField(
+          title: "Choose your username",
+          placeholder: "Enter your username",
+          text: $username,
+          isRequired: true,
+          errorMessage: (hasAttemptedNext && username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) ? "Username is required" : nil
+        )
+        .focused($focusedField, equals: .username)
+        .submitLabel(.next)
+        .onSubmit { focusedField = .link }
+
+        // Link field
+        DarkInputField(
+          title: "Link",
+          placeholder: "https://yoursite.com",
+          text: $link,
+          isRequired: false
+        )
+        .focused($focusedField, equals: .link)
+        .submitLabel(.next)
+        .onSubmit { focusedField = .xTwitter }
+        .keyboardType(.URL)
+        .textInputAutocapitalization(.never)
+
+        // X field
+        DarkInputField(
+          title: "X(twitter)",
+          placeholder: "https://x.com/username",
+          text: $xTwitter,
+          isRequired: false
+        )
+        .focused($focusedField, equals: .xTwitter)
+        .submitLabel(.next)
+        .onSubmit { focusedField = .linkedIn }
+        .textInputAutocapitalization(.never)
+
+        // LinkedIn field
+        DarkInputField(
+          title: "LinkedIn",
+          placeholder: "linkedin/links/here",
+          text: $linkedIn,
+          isRequired: false
+        )
+        .focused($focusedField, equals: .linkedIn)
+        .submitLabel(.next)
+        .onSubmit { focusedField = .wallet }
+        .textInputAutocapitalization(.never)
+
+        VStack(alignment: .leading, spacing: 4) {
+          Text("Export")
+            .font(.system(size: 14, weight: .bold))
+            .foregroundColor(.white)
+          Text("You can do this later or whenever you're ready to export your data.")
+            .font(.system(size: 12))
+            .foregroundColor(Color.Theme.textTertiary)
+        }
+
+        // Wallet field
+        DarkInputField(
+          title: "Link to your ERC20 wallet (?)",
+          placeholder: "0x...",
+          text: $wallet,
+          isRequired: false
+        )
+        .focused($focusedField, equals: .wallet)
+        .submitLabel(.done)
+        .onSubmit { focusedField = nil }
+        .textInputAutocapitalization(.never)
+        .autocorrectionDisabled()
+
+        Spacer(minLength: 40)
+
+        Button(action: {
+          hasAttemptedNext = true
+          focusedField = nil
+          if !username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            HapticFeedbackManager.shared.heavyImpact()
+            onNext()
+          } else {
+            HapticFeedbackManager.shared.errorNotification()
+          }
+        }) {
+          Text("Next")
+        }
+        .buttonStyle(ThemedInvertedButtonStyle())
+        .padding(.bottom, 32)
       }
-      .buttonStyle(ThemedInvertedButtonStyle())
-      .padding(.bottom, 32)
+      .padding(.horizontal, 24)
+      .padding(.top, 40)
     }
-    .padding(.horizontal, 24)
-    .padding(.top, 40)
+    .scrollDismissesKeyboard(.interactively)
     .background(Color.Theme.pageBg.ignoresSafeArea())
+    .toolbar {
+      ToolbarItemGroup(placement: .keyboard) {
+        Spacer()
+        Button("Done") {
+          focusedField = nil
+        }
+        .foregroundColor(Color.Theme.primaryBlue)
+      }
+    }
   }
 }
 
@@ -107,9 +146,16 @@ struct DarkInputField: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 8) {
-      Text(title)
-        .font(.system(size: 14, weight: .bold))
-        .foregroundColor(.white)
+      HStack(spacing: 4) {
+        Text(title)
+          .font(.system(size: 14, weight: .bold))
+          .foregroundColor(.white)
+        if isRequired {
+          Text("*")
+            .font(.system(size: 14, weight: .bold))
+            .foregroundColor(Color.Theme.destructive)
+        }
+      }
 
       TextField("", text: $text)
         .placeholder(when: text.isEmpty) {

--- a/airmeishi/Views/Onboarding/OnboardingFlowView.swift
+++ b/airmeishi/Views/Onboarding/OnboardingFlowView.swift
@@ -14,8 +14,17 @@ struct OnboardingFlowView: View {
   @AppStorage("solidarity.onboarding.completed") private var onboardingCompleted = false
   @AppStorage("theme_selected_animal") private var savedAvatar: String?
   @AppStorage("user_profile_name") private var profileName = ""
+  @AppStorage("solidarity.onboarding.step") private var persistedStep: Int = 0
 
-  @State private var step: Step = .welcome
+  private var step: Step {
+    get { Step(rawValue: persistedStep) ?? .welcome }
+  }
+
+  private func goTo(_ newStep: Step) {
+    withAnimation(.easeInOut) {
+      persistedStep = newStep.rawValue
+    }
+  }
 
   // Profile Form Data
   @State private var username = ""
@@ -47,13 +56,13 @@ struct OnboardingFlowView: View {
       switch step {
       case .welcome:
         TerminalWelcomeScreen {
-          withAnimation(.easeInOut) { step = .profileSetup }
+          goTo(.profileSetup)
         }
       case .profileSetup:
         DarkProfileSetupForm(
           onNext: {
-            profileName = username // Save name
-            withAnimation(.easeInOut) { step = .avatarSetup }
+            profileName = username
+            goTo(.avatarSetup)
           },
           username: $username,
           link: $linkText,
@@ -68,10 +77,10 @@ struct OnboardingFlowView: View {
             if let avatar = selectedAvatar {
               savedAvatar = avatar.rawValue
             }
-            withAnimation(.easeInOut) { step = .secureKeys }
+            goTo(.secureKeys)
           },
           onBack: {
-            withAnimation(.easeInOut) { step = .profileSetup }
+            goTo(.profileSetup)
           }
         )
       case .secureKeys:
@@ -98,7 +107,7 @@ struct OnboardingFlowView: View {
       PassportOnboardingFlowView { _ in
         passportScanned = true
         showingPassportFlow = false
-        withAnimation(.easeInOut) { step = .complete }
+        goTo(.complete)
       }
     }
   }
@@ -108,7 +117,7 @@ struct OnboardingFlowView: View {
   private var finalizeKeysStep: some View {
     VStack(alignment: .leading, spacing: 24) {
       HStack {
-        Button(action: { withAnimation { step = .avatarSetup } }) {
+        Button(action: { goTo(.avatarSetup) }) {
           Image(systemName: "chevron.left")
             .foregroundColor(.white)
             .padding(12)
@@ -151,7 +160,7 @@ struct OnboardingFlowView: View {
   private var importContactsStep: some View {
     VStack(alignment: .leading, spacing: 24) {
       HStack {
-        Button(action: { withAnimation { step = .secureKeys } }) {
+        Button(action: { goTo(.secureKeys) }) {
           Image(systemName: "chevron.left")
             .foregroundColor(.white)
             .padding(12)
@@ -195,7 +204,7 @@ struct OnboardingFlowView: View {
             .padding(.vertical, 8)
         } else {
           Button(action: importFromPhone) {
-            Label("Import from Phone", systemImage: "person.crop.circle.badge.down")
+            Label("Import from Phone", systemImage: "person.crop.circle.badge.plus")
           }
           .buttonStyle(ThemedPrimaryButtonStyle())
 
@@ -208,7 +217,7 @@ struct OnboardingFlowView: View {
 
       Spacer()
 
-      Button(action: { withAnimation(.easeInOut) { step = .scanPassport } }) {
+      Button(action: { goTo(.scanPassport) }) {
         Text(importedCount != nil ? "Continue" : "Skip")
       }
       .buttonStyle(ThemedInvertedButtonStyle())
@@ -221,7 +230,7 @@ struct OnboardingFlowView: View {
   private var scanPassportStep: some View {
     VStack(alignment: .leading, spacing: 24) {
       HStack {
-        Button(action: { withAnimation { step = .importContacts } }) {
+        Button(action: { goTo(.importContacts) }) {
           Image(systemName: "chevron.left")
             .foregroundColor(.white)
             .padding(12)
@@ -267,7 +276,7 @@ struct OnboardingFlowView: View {
 
       Spacer()
 
-      Button(action: { withAnimation(.easeInOut) { step = .complete } }) {
+      Button(action: { goTo(.complete) }) {
         Text(passportScanned ? "Continue" : "Skip")
       }
       .buttonStyle(ThemedInvertedButtonStyle())
@@ -316,6 +325,7 @@ struct OnboardingFlowView: View {
 
       Button(action: {
         HapticFeedbackManager.shared.successNotification()
+        persistedStep = 0
         onboardingCompleted = true
       }) {
         Text("Start Using Solidarity")
@@ -364,7 +374,7 @@ struct OnboardingFlowView: View {
           case .success:
             keysGenerated = true
             createInitialBusinessCard()
-            withAnimation { step = .importContacts }
+            goTo(.importContacts)
           case .failure(let error):
             show(error.localizedDescription)
           }

--- a/airmeishi/Views/Onboarding/TerminalWelcomeScreen.swift
+++ b/airmeishi/Views/Onboarding/TerminalWelcomeScreen.swift
@@ -6,6 +6,7 @@ struct TerminalWelcomeScreen: View {
   private let fullText = "Welcome to\nyour new social\nexperiment"
   @State private var showSubtitle = false
   @State private var showNext = false
+  @State private var typingTimer: Timer?
 
   var body: some View {
     VStack {
@@ -50,20 +51,38 @@ struct TerminalWelcomeScreen: View {
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color.Theme.pageBg.ignoresSafeArea())
+    .contentShape(Rectangle())
+    .onTapGesture {
+      skipAnimation()
+    }
     .onAppear(perform: startTyping)
+  }
+
+  private func skipAnimation() {
+    guard !showNext else { return }
+    typingTimer?.invalidate()
+    typingTimer = nil
+    displayedText = fullText
+    withAnimation(.easeIn(duration: 0.3)) {
+      showSubtitle = true
+    }
+    withAnimation(.spring()) {
+      showNext = true
+    }
   }
 
   private func startTyping() {
     let characters = Array(fullText)
     var index = 0
 
-    Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { timer in
+    typingTimer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { timer in
       if index < characters.count {
         displayedText.append(characters[index])
         index += 1
         HapticFeedbackManager.shared.softImpact()
       } else {
         timer.invalidate()
+        typingTimer = nil
         withAnimation(.easeIn(duration: 0.8)) {
           showSubtitle = true
         }

--- a/airmeishi/Views/PeopleViews/PeopleListView.swift
+++ b/airmeishi/Views/PeopleViews/PeopleListView.swift
@@ -66,7 +66,7 @@ struct PeopleListView: View {
             Button {
               importPhoneContacts()
             } label: {
-              Label("Import from Phone", systemImage: "person.crop.circle.badge.down")
+              Label("Import from Phone", systemImage: "person.crop.circle.badge.plus")
             }
 
             Button {

--- a/airmeishi/Views/SettingsViews/SettingsView.swift
+++ b/airmeishi/Views/SettingsViews/SettingsView.swift
@@ -5,15 +5,8 @@ struct SettingsView: View {
   @ObservedObject private var devMode = DeveloperModeManager.shared
   @State private var showingSolidarityQR = false
   @State private var showingDIDList = false
-  @AppStorage("defaultSharingLevel") private var defaultSharingLevel: String = SharingLevel.professional.rawValue
+  @State private var showingOnboarding = false
   @AppStorage("iCloudBackupEnabled") private var iCloudBackupEnabled: Bool = true
-
-  private var sharingLevelBinding: Binding<SharingLevel> {
-    Binding(
-      get: { SharingLevel(rawValue: defaultSharingLevel) ?? .professional },
-      set: { defaultSharingLevel = $0.rawValue }
-    )
-  }
 
   var body: some View {
     NavigationStack {
@@ -39,13 +32,13 @@ struct SettingsView: View {
         }
 
         Section(
-          header: Text("QR Privacy Level"),
-          footer: Text("Controls which fields are included when generating or sharing your QR code.")
+          header: Text("QR Sharing"),
+          footer: Text("Controls which fields and proofs are included when generating your QR code.")
         ) {
-          Picker("Default Level", selection: sharingLevelBinding) {
-            ForEach(SharingLevel.allCases) { level in
-              Label(level.displayName, systemImage: level.icon).tag(level)
-            }
+          NavigationLink {
+            ShareSettingsView()
+          } label: {
+            Label("Share Settings", systemImage: "checklist")
           }
         }
 
@@ -75,6 +68,14 @@ struct SettingsView: View {
           }
         }
 
+        Section("Guide") {
+          Button {
+            showingOnboarding = true
+          } label: {
+            Label("Replay Onboarding", systemImage: "arrow.counterclockwise")
+          }
+        }
+
         Section("About") {
           HStack {
             Text("Version")
@@ -98,6 +99,11 @@ struct SettingsView: View {
       }
       .sheet(isPresented: $showingDIDList) {
         DIDListSheet()
+      }
+      .fullScreenCover(isPresented: $showingOnboarding) {
+        OnboardingReplayView {
+          showingOnboarding = false
+        }
       }
     }
   }
@@ -156,6 +162,29 @@ private struct DIDListSheet: View {
         .textSelection(.enabled)
     }
     .padding(.vertical, 4)
+  }
+}
+
+// MARK: - Onboarding Replay Wrapper
+
+private struct OnboardingReplayView: View {
+  var onDismiss: () -> Void
+
+  var body: some View {
+    ZStack(alignment: .topTrailing) {
+      OnboardingFlowView()
+
+      Button(action: onDismiss) {
+        Image(systemName: "xmark")
+          .font(.system(size: 14, weight: .bold))
+          .foregroundColor(Color.Theme.textSecondary)
+          .padding(10)
+          .background(Color.Theme.searchBg)
+          .overlay(Rectangle().stroke(Color.Theme.divider, lineWidth: 1))
+      }
+      .padding(.top, 54)
+      .padding(.trailing, 20)
+    }
   }
 }
 

--- a/airmeishi/Views/SharingViews/ShareSettingsView.swift
+++ b/airmeishi/Views/SharingViews/ShareSettingsView.swift
@@ -1,0 +1,285 @@
+//
+//  ShareSettingsView.swift
+//  airmeishi
+//
+//  Per-field sharing toggles + proof badge selection.
+//  Replaces SharingLevel (public/professional/personal).
+//
+
+import SwiftUI
+
+struct ShareSettingsView: View {
+  @AppStorage("share_field_title") private var shareTitle = false
+  @AppStorage("share_field_company") private var shareCompany = false
+  @AppStorage("share_field_email") private var shareEmail = false
+  @AppStorage("share_field_phone") private var sharePhone = false
+  @AppStorage("share_field_profileImage") private var shareProfileImage = false
+  @AppStorage("share_field_socialNetworks") private var shareSocialNetworks = false
+  @AppStorage("share_field_skills") private var shareSkills = false
+  @AppStorage("share_proof_is_human") private var shareIsHuman = true
+  @AppStorage("share_proof_age_over_18") private var shareAgeOver18 = false
+
+  @ObservedObject private var identityStore = IdentityDataStore.shared
+  @StateObject private var cardManager = CardManager.shared
+  @StateObject private var qrCodeManager = QRCodeManager.shared
+  @Environment(\.colorScheme) private var colorScheme
+
+  @State private var generatedQRImage: UIImage?
+
+  private var hasPassportClaims: Bool {
+    !identityStore.provableClaims.filter { $0.issuerType == "government" }.isEmpty
+  }
+
+  private var hasHumanClaim: Bool {
+    identityStore.provableClaims.contains { $0.claimType == "is_human" }
+  }
+
+  private var hasAgeClaim: Bool {
+    identityStore.provableClaims.contains { $0.claimType == "age_over_18" }
+  }
+
+  var body: some View {
+    ScrollView {
+      VStack(spacing: 20) {
+        qrPreview
+
+        fieldToggles
+
+        if hasHumanClaim || hasAgeClaim {
+          proofToggles
+        }
+      }
+      .padding(16)
+    }
+    .background(Color.Theme.pageBg.ignoresSafeArea())
+    .navigationTitle("Share Settings")
+    .navigationBarTitleDisplayMode(.inline)
+    .onAppear { refreshQR() }
+    .onChange(of: shareTitle) { _, _ in refreshQR() }
+    .onChange(of: shareCompany) { _, _ in refreshQR() }
+    .onChange(of: shareEmail) { _, _ in refreshQR() }
+    .onChange(of: sharePhone) { _, _ in refreshQR() }
+    .onChange(of: shareProfileImage) { _, _ in refreshQR() }
+    .onChange(of: shareSocialNetworks) { _, _ in refreshQR() }
+    .onChange(of: shareSkills) { _, _ in refreshQR() }
+    .onChange(of: shareIsHuman) { _, _ in refreshQR() }
+    .onChange(of: shareAgeOver18) { _, _ in refreshQR() }
+  }
+
+  // MARK: - QR Preview
+
+  private var qrPreview: some View {
+    VStack(spacing: 12) {
+      Text("QR PREVIEW")
+        .font(.system(size: 12, weight: .bold, design: .monospaced))
+        .foregroundColor(Color.Theme.textTertiary)
+
+      Group {
+        if let generatedQRImage {
+          Image(uiImage: generatedQRImage)
+            .resizable()
+            .interpolation(.none)
+            .scaledToFit()
+        } else {
+          VStack(spacing: 8) {
+            Image(systemName: "qrcode")
+              .font(.system(size: 40))
+              .foregroundColor(Color.Theme.textTertiary)
+            Text("Create a card first")
+              .font(.system(size: 12))
+              .foregroundColor(Color.Theme.textTertiary)
+          }
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+      }
+      .frame(maxWidth: .infinity)
+      .aspectRatio(1, contentMode: .fit)
+      .padding(12)
+      .background(Color.white)
+      .cornerRadius(8)
+    }
+    .padding(16)
+    .background(Color.Theme.cardBg)
+    .overlay(Rectangle().stroke(Color.Theme.divider, lineWidth: 1))
+  }
+
+  // MARK: - Field Toggles
+
+  private var fieldToggles: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      Text("SHARE FIELDS")
+        .font(.system(size: 12, weight: .bold, design: .monospaced))
+        .foregroundColor(Color.Theme.textTertiary)
+        .padding(.bottom, 8)
+
+      VStack(spacing: 1) {
+        fieldRow(icon: "person.text.rectangle", label: "Name", isOn: .constant(true), locked: true)
+        fieldRow(icon: "id.card", label: "Title", isOn: $shareTitle)
+        fieldRow(icon: "building.2", label: "Company", isOn: $shareCompany)
+        fieldRow(icon: "envelope", label: "Email", isOn: $shareEmail)
+        fieldRow(icon: "phone", label: "Phone", isOn: $sharePhone)
+        fieldRow(icon: "person.crop.circle", label: "Profile Image", isOn: $shareProfileImage)
+        fieldRow(icon: "link", label: "Social Networks", isOn: $shareSocialNetworks)
+        fieldRow(icon: "star", label: "Skills", isOn: $shareSkills)
+      }
+      .clipShape(Rectangle())
+      .overlay(Rectangle().stroke(Color.Theme.divider, lineWidth: 1))
+    }
+  }
+
+  // MARK: - Proof Toggles
+
+  private var proofToggles: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      Text("PROOFS")
+        .font(.system(size: 12, weight: .bold, design: .monospaced))
+        .foregroundColor(Color.Theme.textTertiary)
+        .padding(.bottom, 8)
+
+      VStack(spacing: 1) {
+        if hasHumanClaim {
+          proofRow(
+            icon: "person.badge.shield.checkmark.fill",
+            label: "Real Human",
+            badge: "Government",
+            badgeColor: Color.Theme.terminalGreen,
+            isOn: $shareIsHuman
+          )
+        }
+        if hasAgeClaim {
+          proofRow(
+            icon: "calendar.badge.checkmark",
+            label: "Age 18+",
+            badge: "Government",
+            badgeColor: Color.Theme.terminalGreen,
+            isOn: $shareAgeOver18
+          )
+        }
+      }
+      .clipShape(Rectangle())
+      .overlay(Rectangle().stroke(Color.Theme.divider, lineWidth: 1))
+    }
+  }
+
+  // MARK: - Row Components
+
+  private func fieldRow(icon: String, label: String, isOn: Binding<Bool>, locked: Bool = false) -> some View {
+    HStack(spacing: 12) {
+      Image(systemName: icon)
+        .font(.system(size: 14))
+        .foregroundColor(isOn.wrappedValue ? Color.Theme.terminalGreen : Color.Theme.textTertiary)
+        .frame(width: 20)
+
+      Text(label)
+        .font(.system(size: 14, weight: .medium))
+        .foregroundColor(isOn.wrappedValue ? Color.Theme.textPrimary : Color.Theme.textSecondary)
+
+      Spacer()
+
+      if locked {
+        Image(systemName: "lock.fill")
+          .font(.system(size: 12))
+          .foregroundColor(Color.Theme.textTertiary)
+      } else {
+        Image(systemName: isOn.wrappedValue ? "checkmark.square.fill" : "square")
+          .font(.system(size: 18))
+          .foregroundColor(isOn.wrappedValue ? Color.Theme.terminalGreen : Color.Theme.textTertiary)
+      }
+    }
+    .padding(.horizontal, 16)
+    .padding(.vertical, 12)
+    .background(Color.Theme.searchBg)
+    .contentShape(Rectangle())
+    .onTapGesture {
+      guard !locked else { return }
+      HapticFeedbackManager.shared.rigidImpact()
+      isOn.wrappedValue.toggle()
+    }
+  }
+
+  private func proofRow(icon: String, label: String, badge: String, badgeColor: Color, isOn: Binding<Bool>) -> some View {
+    HStack(spacing: 12) {
+      Image(systemName: icon)
+        .font(.system(size: 14))
+        .foregroundColor(isOn.wrappedValue ? badgeColor : Color.Theme.textTertiary)
+        .frame(width: 20)
+
+      VStack(alignment: .leading, spacing: 2) {
+        Text(label)
+          .font(.system(size: 14, weight: .medium))
+          .foregroundColor(isOn.wrappedValue ? Color.Theme.textPrimary : Color.Theme.textSecondary)
+        Text(badge)
+          .font(.system(size: 10, weight: .bold, design: .monospaced))
+          .foregroundColor(badgeColor)
+      }
+
+      Spacer()
+
+      Image(systemName: isOn.wrappedValue ? "checkmark.square.fill" : "square")
+        .font(.system(size: 18))
+        .foregroundColor(isOn.wrappedValue ? badgeColor : Color.Theme.textTertiary)
+    }
+    .padding(.horizontal, 16)
+    .padding(.vertical, 12)
+    .background(Color.Theme.searchBg)
+    .contentShape(Rectangle())
+    .onTapGesture {
+      HapticFeedbackManager.shared.rigidImpact()
+      isOn.wrappedValue.toggle()
+    }
+  }
+
+  // MARK: - QR Generation
+
+  private func refreshQR() {
+    guard let card = cardManager.businessCards.first else {
+      generatedQRImage = nil
+      return
+    }
+    let fields = enabledFields
+    let result = qrCodeManager.generateQRCode(for: card, fields: fields)
+    if case .success(let image) = result {
+      generatedQRImage = image
+    }
+  }
+
+  var enabledFields: Set<BusinessCardField> {
+    var fields: Set<BusinessCardField> = [.name]
+    if shareTitle { fields.insert(.title) }
+    if shareCompany { fields.insert(.company) }
+    if shareEmail { fields.insert(.email) }
+    if sharePhone { fields.insert(.phone) }
+    if shareProfileImage { fields.insert(.profileImage) }
+    if shareSocialNetworks { fields.insert(.socialNetworks) }
+    if shareSkills { fields.insert(.skills) }
+    return fields
+  }
+}
+
+// MARK: - Global helper to read share settings from AppStorage
+
+enum ShareSettingsReader {
+  static var enabledFields: Set<BusinessCardField> {
+    var fields: Set<BusinessCardField> = [.name]
+    if UserDefaults.standard.bool(forKey: "share_field_title") { fields.insert(.title) }
+    if UserDefaults.standard.bool(forKey: "share_field_company") { fields.insert(.company) }
+    if UserDefaults.standard.bool(forKey: "share_field_email") { fields.insert(.email) }
+    if UserDefaults.standard.bool(forKey: "share_field_phone") { fields.insert(.phone) }
+    if UserDefaults.standard.bool(forKey: "share_field_profileImage") { fields.insert(.profileImage) }
+    if UserDefaults.standard.bool(forKey: "share_field_socialNetworks") { fields.insert(.socialNetworks) }
+    if UserDefaults.standard.bool(forKey: "share_field_skills") { fields.insert(.skills) }
+    return fields
+  }
+
+  static var shareIsHuman: Bool {
+    // Default true — UserDefaults returns false for unset keys, so check registration
+    if UserDefaults.standard.object(forKey: "share_proof_is_human") == nil {
+      return true
+    }
+    return UserDefaults.standard.bool(forKey: "share_proof_is_human")
+  }
+
+  static var shareAgeOver18: Bool {
+    UserDefaults.standard.bool(forKey: "share_proof_age_over_18")
+  }
+}

--- a/airmeishi/Views/SharingViews/SharingTabView.swift
+++ b/airmeishi/Views/SharingViews/SharingTabView.swift
@@ -2,8 +2,8 @@
 //  SharingTabView.swift
 //  airmeishi
 //
-//  Main sharing hub: radar matching view with UWB spatial sensing,
-//  QR scanner access via toolbar, and peer discovery.
+//  Main sharing hub: radar matching view with peer discovery,
+//  inline QR code, and Share Settings navigation.
 //
 
 import SwiftUI
@@ -12,120 +12,91 @@ struct SharingTabView: View {
   @StateObject private var proximityManager = ProximityManager.shared
   @StateObject private var cardManager = CardManager.shared
   @StateObject private var niManager = NearbyInteractionManager.shared
+  @StateObject private var qrCodeManager = QRCodeManager.shared
   @Environment(\.colorScheme) private var colorScheme
+
   @State private var showingScanSheet = false
-  @State private var showingShareSheet = false
   @State private var showingNearbySheet = false
   @State private var showingReceivedCard = false
   @State private var isMatching = false
+  @State private var showingShareActivity = false
+  @State private var generatedQRImage: UIImage?
 
   var body: some View {
     NavigationStack {
-      ZStack {
-        // Background gradient
-        LinearGradient(
-          colors: Color.Theme.pageGradient(for: colorScheme),
-          startPoint: .top,
-          endPoint: .bottom
-        )
-        .ignoresSafeArea()
-
+      ScrollView {
         VStack(spacing: 0) {
-          Spacer()
-
-          // Radar view
+          // Radar hero
           RadarMatchingView(
             peers: proximityManager.nearbyPeers,
             isMatching: isMatching,
             niManager: niManager
           )
-          .frame(height: 300)
+          .frame(height: 260)
           .onTapGesture {
             if !proximityManager.nearbyPeers.isEmpty {
               showingNearbySheet = true
             }
           }
 
-          Spacer().frame(height: 24)
+          Spacer().frame(height: 16)
 
-          // Status text
+          // Status + matching button
           VStack(spacing: 8) {
             Text(isMatching ? "Scanning Nearby" : "Ready To Match")
-              .font(.system(size: 22, weight: .bold))
+              .font(.system(size: 20, weight: .bold))
               .foregroundColor(Color.Theme.textPrimary)
 
             Text(statusSubtitle)
-              .font(.system(size: 14))
+              .font(.system(size: 13))
               .foregroundColor(Color.Theme.textSecondary)
               .multilineTextAlignment(.center)
               .padding(.horizontal, 40)
           }
 
-          Spacer().frame(height: 28)
+          Spacer().frame(height: 16)
 
-          // Main action button
           Button(action: toggleMatching) {
             HStack(spacing: 10) {
               Image(systemName: isMatching ? "stop.fill" : "dot.radiowaves.left.and.right")
-                .font(.system(size: 16, weight: .semibold))
+                .font(.system(size: 15, weight: .semibold))
               Text(isMatching ? "Stop Matching" : "Start Matching")
-                .font(.system(size: 16, weight: .semibold))
+                .font(.system(size: 15, weight: .semibold))
             }
           }
           .buttonStyle(ThemedPrimaryButtonStyle())
           .padding(.horizontal, 48)
 
-          Spacer().frame(height: 16)
-
-          // QR code quick actions
-          HStack(spacing: 12) {
-            Button {
-              showingScanSheet = true
-            } label: {
-              HStack(spacing: 8) {
-                Image(systemName: "qrcode.viewfinder")
-                  .font(.system(size: 16, weight: .semibold))
-                Text("Scan QR")
-                  .font(.system(size: 14, weight: .semibold))
-              }
-              .frame(maxWidth: .infinity)
-              .padding(.vertical, 12)
-              .foregroundColor(Color.Theme.textPrimary)
-              .background(Color.Theme.searchBg)
-              .overlay(Rectangle().stroke(Color.Theme.divider, lineWidth: 1))
-            }
-            .buttonStyle(.plain)
-
-            Button {
-              showingShareSheet = true
-            } label: {
-              HStack(spacing: 8) {
-                Image(systemName: "qrcode")
-                  .font(.system(size: 16, weight: .semibold))
-                Text("My QR")
-                  .font(.system(size: 14, weight: .semibold))
-              }
-              .frame(maxWidth: .infinity)
-              .padding(.vertical, 12)
-              .foregroundColor(Color.Theme.textPrimary)
-              .background(Color.Theme.searchBg)
-              .overlay(Rectangle().stroke(Color.Theme.divider, lineWidth: 1))
-            }
-            .buttonStyle(.plain)
-          }
-          .padding(.horizontal, 48)
-
-          // UWB status pill
+          // UWB status
           if niManager.isSupported, niManager.spatialState.isActive {
             uwbStatusPill
-              .padding(.top, 12)
+              .padding(.top, 10)
           }
 
-          Spacer()
+          Spacer().frame(height: 24)
+
+          // QR code section
+          qrSection
+            .padding(.horizontal, 16)
+
+          Spacer().frame(height: 16)
+
+          // Quick actions
+          quickActions
+            .padding(.horizontal, 16)
+
+          Spacer().frame(height: 100)
         }
-        .padding(.bottom, 80)
       }
-      .navigationTitle("Sharing")
+      .background(
+        LinearGradient(
+          colors: Color.Theme.pageGradient(for: colorScheme),
+          startPoint: .top,
+          endPoint: .bottom
+        )
+        .ignoresSafeArea()
+      )
+      .navigationTitle("Share")
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
         ToolbarItem(placement: .navigationBarLeading) {
@@ -136,29 +107,14 @@ struct SharingTabView: View {
               .foregroundColor(Color.Theme.toolbarTint(for: colorScheme))
           }
         }
-        ToolbarItem(placement: .navigationBarTrailing) {
-          Button {
-            showingShareSheet = true
-          } label: {
-            Image(systemName: "square.and.arrow.up")
-              .foregroundColor(Color.Theme.toolbarTint(for: colorScheme))
-          }
-        }
       }
     }
     .onAppear {
       setupSpatialTrigger()
+      refreshQR()
     }
     .sheet(isPresented: $showingScanSheet) {
       ScanTabView()
-    }
-    .sheet(isPresented: $showingShareSheet) {
-      ShareCardPickerSheet(
-        cards: cardManager.businessCards,
-        onStart: { card, level in proximityManager.startAdvertising(with: card, sharingLevel: level) },
-        onStop: { proximityManager.stopAdvertising() },
-        isAdvertising: proximityManager.getSharingStatus().isAdvertising
-      )
     }
     .sheet(isPresented: $showingNearbySheet) {
       NearbyPeersSheet(
@@ -174,6 +130,151 @@ struct SharingTabView: View {
         ReceivedCardView(card: card)
       }
     }
+    .sheet(isPresented: $showingShareActivity) {
+      let text = shareText
+      if !text.isEmpty {
+        ShareSheet(activityItems: [text])
+      }
+    }
+  }
+
+  // MARK: - QR Section
+
+  private var qrSection: some View {
+    VStack(spacing: 12) {
+      HStack {
+        Text("MY QR")
+          .font(.system(size: 12, weight: .bold, design: .monospaced))
+          .foregroundColor(Color.Theme.textTertiary)
+
+        Spacer()
+
+        NavigationLink {
+          ShareSettingsView()
+        } label: {
+          HStack(spacing: 4) {
+            Image(systemName: "gearshape")
+              .font(.system(size: 12))
+            Text("Settings")
+              .font(.system(size: 12, weight: .medium))
+          }
+          .foregroundColor(Color.Theme.primaryBlue)
+        }
+      }
+
+      Group {
+        if let generatedQRImage {
+          Image(uiImage: generatedQRImage)
+            .resizable()
+            .interpolation(.none)
+            .scaledToFit()
+        } else {
+          VStack(spacing: 8) {
+            Image(systemName: "qrcode")
+              .font(.system(size: 36))
+              .foregroundColor(Color.Theme.textTertiary)
+            Text("Create a card to generate QR")
+              .font(.system(size: 12))
+              .foregroundColor(Color.Theme.textTertiary)
+          }
+          .frame(maxWidth: .infinity)
+          .frame(height: 180)
+        }
+      }
+      .frame(maxWidth: .infinity)
+      .aspectRatio(1, contentMode: .fit)
+      .padding(10)
+      .background(Color.white)
+      .cornerRadius(8)
+
+      // Active proof badges
+      proofBadges
+    }
+    .padding(16)
+    .background(Color.Theme.cardSurface(for: colorScheme))
+    .overlay(Rectangle().stroke(Color.Theme.cardBorder(for: colorScheme), lineWidth: 1))
+  }
+
+  private var proofBadges: some View {
+    let claims = IdentityDataStore.shared.provableClaims.filter { $0.issuerType == "government" }
+    return Group {
+      if !claims.isEmpty {
+        HStack(spacing: 8) {
+          if ShareSettingsReader.shareIsHuman,
+             claims.contains(where: { $0.claimType == "is_human" }) {
+            proofPill(label: "Real Human", color: Color.Theme.terminalGreen)
+          }
+          if ShareSettingsReader.shareAgeOver18,
+             claims.contains(where: { $0.claimType == "age_over_18" }) {
+            proofPill(label: "Age 18+", color: Color.Theme.terminalGreen)
+          }
+          Spacer()
+        }
+      }
+    }
+  }
+
+  private func proofPill(label: String, color: Color) -> some View {
+    HStack(spacing: 4) {
+      Circle()
+        .fill(color)
+        .frame(width: 6, height: 6)
+      Text(label)
+        .font(.system(size: 11, weight: .semibold, design: .monospaced))
+        .foregroundColor(color)
+    }
+    .padding(.horizontal, 8)
+    .padding(.vertical, 4)
+    .background(
+      Capsule()
+        .fill(color.opacity(0.12))
+    )
+  }
+
+  // MARK: - Quick Actions
+
+  private var quickActions: some View {
+    HStack(spacing: 12) {
+      Button {
+        showingScanSheet = true
+      } label: {
+        HStack(spacing: 8) {
+          Image(systemName: "qrcode.viewfinder")
+            .font(.system(size: 16, weight: .semibold))
+          Text("Scan QR")
+            .font(.system(size: 14, weight: .semibold))
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 12)
+        .foregroundColor(Color.Theme.textPrimary)
+        .background(Color.Theme.searchBg)
+        .overlay(Rectangle().stroke(Color.Theme.divider, lineWidth: 1))
+      }
+      .buttonStyle(.plain)
+
+      Button {
+        showingShareActivity = true
+      } label: {
+        HStack(spacing: 8) {
+          Image(systemName: "square.and.arrow.up")
+            .font(.system(size: 16, weight: .semibold))
+          Text("Share")
+            .font(.system(size: 14, weight: .semibold))
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 12)
+        .foregroundColor(Color.Theme.textPrimary)
+        .background(Color.Theme.searchBg)
+        .overlay(Rectangle().stroke(Color.Theme.divider, lineWidth: 1))
+      }
+      .buttonStyle(.plain)
+    }
+  }
+
+  private var shareText: String {
+    guard let card = cardManager.businessCards.first else { return "" }
+    let filtered = card.filteredCard(for: ShareSettingsReader.enabledFields)
+    return filtered.vCardData
   }
 
   // MARK: - Actions
@@ -196,9 +297,21 @@ struct SharingTabView: View {
       if count > 0 {
         return "Found \(count) nearby \(count == 1 ? "peer" : "peers"). Tap the radar to connect."
       }
-      return "Searching for nearby peers... Keep the app open."
+      return "Searching for nearby peers..."
     }
-    return "Start matching to discover nearby people and exchange cards."
+    return "Start matching to discover nearby people."
+  }
+
+  private func refreshQR() {
+    guard let card = cardManager.businessCards.first else {
+      generatedQRImage = nil
+      return
+    }
+    let fields = ShareSettingsReader.enabledFields
+    let result = qrCodeManager.generateQRCode(for: card, fields: fields)
+    if case .success(let image) = result {
+      generatedQRImage = image
+    }
   }
 
   // MARK: - UWB
@@ -262,7 +375,7 @@ struct SharingTabView: View {
   }
 }
 
-// MARK: - Radar Matching View
+// MARK: - Radar Matching View (kept from original)
 
 struct RadarMatchingView: View {
   let peers: [ProximityPeer]
@@ -280,7 +393,6 @@ struct RadarMatchingView: View {
   var body: some View {
     GeometryReader { geo in
       let size = min(geo.size.width, geo.size.height)
-      let center = CGPoint(x: geo.size.width / 2, y: geo.size.height / 2)
 
       ZStack {
         // Expanding pulse rings
@@ -336,7 +448,7 @@ struct RadarMatchingView: View {
 
         // Peer avatars
         ForEach(Array(peers.prefix(8).enumerated()), id: \.element.id) { index, peer in
-          peerDot(peer: peer, index: index, total: min(peers.count, 8), center: center, radius: size * 0.35)
+          peerDot(peer: peer, index: index, total: min(peers.count, 8), radius: size * 0.35)
         }
       }
       .frame(width: geo.size.width, height: geo.size.height)
@@ -358,7 +470,6 @@ struct RadarMatchingView: View {
   }
 
   private func startPulse() {
-    // Staggered expanding pulse animation
     withAnimation(.easeOut(duration: 3.0).repeatForever(autoreverses: false)) {
       pulseScale1 = 1.0
       pulseOpacity1 = 0.0
@@ -377,7 +488,7 @@ struct RadarMatchingView: View {
     }
   }
 
-  private func peerDot(peer: ProximityPeer, index: Int, total: Int, center: CGPoint, radius: CGFloat) -> some View {
+  private func peerDot(peer: ProximityPeer, index: Int, total: Int, radius: CGFloat) -> some View {
     let angle = (2 * .pi / Double(total)) * Double(index) - .pi / 2
     let x = cos(angle) * Double(radius)
     let y = sin(angle) * Double(radius)

--- a/airmeishi/Views/SharingViews/SharingTabView.swift
+++ b/airmeishi/Views/SharingViews/SharingTabView.swift
@@ -21,6 +21,7 @@ struct SharingTabView: View {
   @State private var isMatching = false
   @State private var showingShareActivity = false
   @State private var generatedQRImage: UIImage?
+  @AppStorage("sharing_qr_expanded") private var isQRExpanded: Bool = true
 
   var body: some View {
     NavigationStack {
@@ -144,32 +145,35 @@ struct SharingTabView: View {
     let card = cardManager.businessCards.first
 
     return VStack(spacing: 0) {
-      // QR code with white background
-      ZStack {
-        if let generatedQRImage {
-          Image(uiImage: generatedQRImage)
-            .resizable()
-            .interpolation(.none)
-            .scaledToFit()
-            .padding(24)
-        } else {
-          VStack(spacing: 10) {
-            Image(systemName: "qrcode")
-              .font(.system(size: 44))
-              .foregroundColor(Color(white: 0.78))
-            Text("Create a card to generate QR")
-              .font(.system(size: 12, design: .monospaced))
-              .foregroundColor(Color(white: 0.6))
+      // Collapsible QR code with white background
+      if isQRExpanded {
+        ZStack {
+          if let generatedQRImage {
+            Image(uiImage: generatedQRImage)
+              .resizable()
+              .interpolation(.none)
+              .scaledToFit()
+              .padding(24)
+          } else {
+            VStack(spacing: 10) {
+              Image(systemName: "qrcode")
+                .font(.system(size: 44))
+                .foregroundColor(Color(white: 0.78))
+              Text("Create a card to generate QR")
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundColor(Color(white: 0.6))
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 200)
           }
-          .frame(maxWidth: .infinity)
-          .frame(height: 200)
         }
+        .frame(maxWidth: .infinity)
+        .aspectRatio(1, contentMode: .fit)
+        .background(Color.white)
+        .transition(.opacity.combined(with: .move(edge: .top)))
       }
-      .frame(maxWidth: .infinity)
-      .aspectRatio(1, contentMode: .fit)
-      .background(Color.white)
 
-      // Card info footer
+      // Card info footer (always visible, tappable to toggle QR)
       VStack(spacing: 10) {
         // Name + avatar row
         HStack(spacing: 10) {
@@ -196,6 +200,21 @@ struct SharingTabView: View {
           }
 
           Spacer()
+
+          // Collapse/expand chevron
+          Button {
+            withAnimation(.easeInOut(duration: 0.25)) {
+              isQRExpanded.toggle()
+            }
+          } label: {
+            Image(systemName: "chevron.up")
+              .font(.system(size: 12, weight: .semibold))
+              .foregroundColor(Color.Theme.textTertiary)
+              .rotationEffect(.degrees(isQRExpanded ? 0 : 180))
+              .padding(8)
+              .background(Color.Theme.searchBg)
+              .overlay(Rectangle().stroke(Color.Theme.divider, lineWidth: 1))
+          }
 
           NavigationLink {
             ShareSettingsView()

--- a/airmeishi/Views/SharingViews/SharingTabView.swift
+++ b/airmeishi/Views/SharingViews/SharingTabView.swift
@@ -141,58 +141,105 @@ struct SharingTabView: View {
   // MARK: - QR Section
 
   private var qrSection: some View {
-    VStack(spacing: 12) {
-      HStack {
-        Text("MY QR")
-          .font(.system(size: 12, weight: .bold, design: .monospaced))
-          .foregroundColor(Color.Theme.textTertiary)
+    let card = cardManager.businessCards.first
 
-        Spacer()
-
-        NavigationLink {
-          ShareSettingsView()
-        } label: {
-          HStack(spacing: 4) {
-            Image(systemName: "gearshape")
-              .font(.system(size: 12))
-            Text("Settings")
-              .font(.system(size: 12, weight: .medium))
-          }
-          .foregroundColor(Color.Theme.primaryBlue)
-        }
-      }
-
-      Group {
+    return VStack(spacing: 0) {
+      // QR code with white background
+      ZStack {
         if let generatedQRImage {
           Image(uiImage: generatedQRImage)
             .resizable()
             .interpolation(.none)
             .scaledToFit()
+            .padding(24)
         } else {
-          VStack(spacing: 8) {
+          VStack(spacing: 10) {
             Image(systemName: "qrcode")
-              .font(.system(size: 36))
-              .foregroundColor(Color.Theme.textTertiary)
+              .font(.system(size: 44))
+              .foregroundColor(Color(white: 0.78))
             Text("Create a card to generate QR")
-              .font(.system(size: 12))
-              .foregroundColor(Color.Theme.textTertiary)
+              .font(.system(size: 12, design: .monospaced))
+              .foregroundColor(Color(white: 0.6))
           }
           .frame(maxWidth: .infinity)
-          .frame(height: 180)
+          .frame(height: 200)
         }
       }
       .frame(maxWidth: .infinity)
       .aspectRatio(1, contentMode: .fit)
-      .padding(10)
       .background(Color.white)
-      .cornerRadius(8)
 
-      // Active proof badges
-      proofBadges
+      // Card info footer
+      VStack(spacing: 10) {
+        // Name + avatar row
+        HStack(spacing: 10) {
+          if let animal = card?.animal,
+             let img = UIImage(named: animal.imageBasename) {
+            Image(uiImage: img)
+              .resizable()
+              .scaledToFill()
+              .frame(width: 32, height: 32)
+              .clipShape(Circle())
+              .overlay(Circle().stroke(Color.Theme.divider, lineWidth: 1))
+          }
+
+          VStack(alignment: .leading, spacing: 2) {
+            Text(card?.name ?? "No Card")
+              .font(.system(size: 15, weight: .semibold))
+              .foregroundColor(Color.Theme.textPrimary)
+              .lineLimit(1)
+
+            Text(sharedFieldsSummary)
+              .font(.system(size: 11, design: .monospaced))
+              .foregroundColor(Color.Theme.textTertiary)
+              .lineLimit(1)
+          }
+
+          Spacer()
+
+          NavigationLink {
+            ShareSettingsView()
+          } label: {
+            Image(systemName: "slider.horizontal.3")
+              .font(.system(size: 14))
+              .foregroundColor(Color.Theme.textSecondary)
+              .padding(8)
+              .background(Color.Theme.searchBg)
+              .overlay(Rectangle().stroke(Color.Theme.divider, lineWidth: 1))
+          }
+        }
+
+        // Proof badges
+        proofBadges
+      }
+      .padding(.horizontal, 16)
+      .padding(.vertical, 12)
+      .background(Color.Theme.cardSurface(for: colorScheme))
     }
-    .padding(16)
-    .background(Color.Theme.cardSurface(for: colorScheme))
-    .overlay(Rectangle().stroke(Color.Theme.cardBorder(for: colorScheme), lineWidth: 1))
+    .clipShape(RoundedRectangle(cornerRadius: 12))
+    .overlay(
+      RoundedRectangle(cornerRadius: 12)
+        .stroke(Color.Theme.cardBorder(for: colorScheme), lineWidth: 1)
+    )
+    .shadow(color: .black.opacity(0.08), radius: 12, x: 0, y: 4)
+  }
+
+  private var sharedFieldsSummary: String {
+    let fields = ShareSettingsReader.enabledFields
+    let labels = fields.sorted(by: { $0.rawValue < $1.rawValue }).compactMap { field -> String? in
+      switch field {
+      case .name: return nil // always on, skip
+      case .title: return "title"
+      case .company: return "company"
+      case .email: return "email"
+      case .phone: return "phone"
+      case .profileImage: return "photo"
+      case .socialNetworks: return "socials"
+      case .skills: return "skills"
+      }
+    }
+    if labels.isEmpty { return "name only" }
+    return "name + " + labels.joined(separator: ", ")
   }
 
   private var proofBadges: some View {

--- a/claude.md
+++ b/claude.md
@@ -220,7 +220,7 @@ airmeishi/
 | SecureKeyManager volatile | Curve25519 keys in-memory only, regenerated each launch | HIGH |
 | Semaphore sync stubbed | `syncRootFromNetwork()` / `pushUpdatesToNetwork()` return false | HIGH |
 | Contact merge silent | Auto-deduplicates by businessCard.id, no UI merge prompt | LOW |
-| Tab structure mismatch | 5 tabs currently vs spec 3-tab (People/Scan/Me) | INFO |
+| SharingLevel still in services | `SharingLevel` enum kept for backward compat; services/tests still reference it | LOW |
 | Legacy Contact struct | `Contact.swift` (Codable) lacks spec fields; only `ContactEntity` has them | LOW |
 
 ### Known TODOs in Code
@@ -260,11 +260,51 @@ airmeishi/
 
 **Present Proof**: Scan QR / Self-initiated → Review Request → Biometric + Sign → Submit VP Token → Success
 
-### Spec Tab Structure
+### Spec Tab Structure (v1.2)
 
 ```
-People (person.2.fill) | Scan (qrcode.viewfinder) | Me (person.text.rectangle)
+People (person.2.fill) | Share (dot.radiowaves.up.forward) | Me (person.text.rectangle)
 ```
+
+- **Share tab** = `SharingTabView`（radar/orbit peer discovery + QR）
+- QR scanner 從 sheet 開啟（Share tab 內的 "Scan QR" 按鈕），不是獨立 tab
+- `ScanTabView` 仍存在，但作為 `.sheet` 使用
+
+### Share Tab Layout
+
+```
+┌────────────────────────────────┐
+│       [Radar / Orbit view]     │  ← hero, MPC peer discovery
+│       [Start / Stop Matching]  │
+│                                │
+│          ┌──────────┐          │
+│          │  QR Code  │          │  ← VP format, reflects share settings
+│          └──────────┘          │
+│       ⚙️ Share Settings →      │  ← NavigationLink → ShareSettingsView
+│                                │
+│   [Scan QR]      [My QR]      │  ← quick actions
+└────────────────────────────────┘
+```
+
+### Share Settings（獨立頁面，從 Share tab 跳轉）
+
+```
+── Share Fields ──
+✅ Name         (locked, always on)
+⬜ Title
+⬜ Company
+⬜ Email
+⬜ Phone
+
+── Proofs ──
+✅ Real Human    (default on, if passport claim exists)
+⬜ Age 18+       (if passport claim exists)
+```
+
+- 以 `@AppStorage` 持久化用戶的欄位選擇
+- QR payload = VP（Verifiable Presentation），包含選取的 card fields + proof badges
+- **取消 `SharingLevel`**（public/professional/personal）— 改為逐欄位 toggle，預設最少資訊（僅 name）
+- `ShareCardPickerSheet` 由 `ShareSettingsView` 取代
 
 ### Spec Data Models
 
@@ -314,7 +354,7 @@ People (person.2.fill) | Scan (qrcode.viewfinder) | Me (person.text.rectangle)
 | 6 | Ichigo-ichie (bidirectional 140 chars) | P0 |
 | 7 | Proof presentation (OID4VP) | P0 |
 | 8 | Proof verification (QR scan) | P0 |
-| 9 | 3-Tab navigation | P0 |
+| 9 | 3-Tab navigation (People/Share/Me) | P0 |
 | 10 | iCloud backup | P1 |
 | 11 | Full onboarding flow | P1 |
 


### PR DESCRIPTION
## Summary
Implements Share Settings feature (per-field toggles) and tab structure redesign from spec v1.2:

- **Tab structure**: Renamed Scan → Share tab (People/Share/Me with new icon `dot.radiowaves.up.forward`)
- **ShareSettingsView**: New view with per-field toggles + proof badges (replaces `SharingLevel` picker)
- **QR generation**: Updated to respect field selections via `@AppStorage` persistence
- **Share tab layout**: Integrated QR inline + Settings link + Scan/Share quick actions
- **Replay onboarding**: Added "Replay Onboarding" button in Settings Guide section

## Test plan
- [ ] Open Settings → Guide → Replay Onboarding (runs full flow again, dismiss with ×)
- [ ] Open Share tab → QR section → Settings → toggle fields (QR updates in real-time)
- [ ] Verify Name is always included, other fields optional
- [ ] Verify proof badges show only when passport claims exist
- [ ] Check that toggles persist across app restarts via `@AppStorage`

🤖 Generated with Claude Code